### PR TITLE
fix socid fetch

### DIFF
--- a/class/actions_dolistorextract.class.php
+++ b/class/actions_dolistorextract.class.php
@@ -424,7 +424,11 @@ class ActionsDolistorextract
 							$searchSoc = $res->rowid;
 						}
 					} else {
-						$searchSoc = $socStatic->fetch($contact->socid);  // Retourne -2 si on trouve plusieurs Tiers
+						// note societe class fetch returns 1 on success, not socid
+						$resSearch = $socStatic->fetch($contact->socid);  // Retourne -2 si on trouve plusieurs Tiers
+                        if ($resSearch) {
+                            $searchSoc = $socStatic->id;
+                        }
 					}
 				}
 			}


### PR DESCRIPTION
Some lines below you have

```
$socid = $searchSoc some lines below ...
```

Then searchSoc = 1 (societe fetch returns 1 on success, not socid) then categories are all the time linked to socid = 1 i think ... please double check before applying that PR
